### PR TITLE
Change the updateCollection method to be public

### DIFF
--- a/src/marionette.sliding-view.js
+++ b/src/marionette.sliding-view.js
@@ -25,7 +25,7 @@ Mn.SlidingView = Mn.CollectionView.extend({
     // Get our initial boundaries, and then update the collection
     this._lowerBound = _.result(this, 'initialLowerBound');
     this._upperBound = _.result(this, 'initialUpperBound');
-    this._updateCollection();
+    this.updateCollection();
 
     // If no onUpdateEvent was defined, then we set one
     // using the `throttle` method.
@@ -86,7 +86,7 @@ Mn.SlidingView = Mn.CollectionView.extend({
 
     // Defer an update for 50ms. This prevents many renders when scrolling fast.
     this._deferredUpdateId = setTimeout(() => {
-      this._updateCollection();
+      this.updateCollection();
     }, 50);
   },
 
@@ -108,7 +108,7 @@ Mn.SlidingView = Mn.CollectionView.extend({
   // 1. Collection#set performs a 'smart' update at the data layer
   // 2. CollectionView performs a 'smart' update of the view layer
   //    whenever the data layer changes
-  _updateCollection() {
+  updateCollection() {
     this.collection.set(this.pruneCollection(this._lowerBound, this._upperBound));
   }
 });

--- a/test/unit/boundaries.js
+++ b/test/unit/boundaries.js
@@ -26,7 +26,7 @@ describe('When boundary methods are specified, and the throttled method is calle
     });
 
     stub(slidingView, 'getUpperBound');
-    spy(slidingView, '_updateCollection');
+    spy(slidingView, 'updateCollection');
   });
 
   afterEach(() => {
@@ -39,7 +39,7 @@ describe('When boundary methods are specified, and the throttled method is calle
     });
 
     it('should not update the collection', () => {
-      expect(slidingView._updateCollection).to.not.have.been.called;
+      expect(slidingView.updateCollection).to.not.have.been.called;
     });
 
     it('should pass the lower bound to the upperBound call', () => {
@@ -56,7 +56,7 @@ describe('When boundary methods are specified, and the throttled method is calle
     });
 
     it('should not update the collection', () => {
-      expect(slidingView._updateCollection).to.not.have.been.called;
+      expect(slidingView.updateCollection).to.not.have.been.called;
     });
   });
 
@@ -67,7 +67,7 @@ describe('When boundary methods are specified, and the throttled method is calle
     });
 
     it('should call the update collection method', () => {
-      expect(slidingView._updateCollection).to.have.been.calledOnce;
+      expect(slidingView.updateCollection).to.have.been.calledOnce;
     });
 
     it('should set the collection correctly', () => {
@@ -85,7 +85,7 @@ describe('When boundary methods are specified, and the throttled method is calle
     });
 
     it('should only update the collection once', () => {
-      expect(slidingView._updateCollection).to.have.been.calledOnce;
+      expect(slidingView.updateCollection).to.have.been.calledOnce;
     });
   });
 
@@ -113,7 +113,7 @@ describe('When boundary methods are specified, and the throttled method is calle
     });
 
     it('should only update the collection once', () => {
-      expect(slidingView._updateCollection).to.have.been.calledOnce;
+      expect(slidingView.updateCollection).to.have.been.calledOnce;
     });
   });
 });


### PR DESCRIPTION
Useful for manually triggering updates when the reference collection
changes.